### PR TITLE
"Fix" custom error messages on more recent versions of Node

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -334,7 +334,7 @@ var create = exports.create = function(options) {
             enumerable: false,
             get: function() {
                 if (!formattedStack) {
-                    formattedStack = stack.stack.replace('[object Object]', 'Error: ' + this.message);
+                    formattedStack = stack.stack.replace(/^(Error|\[object Object\])/, 'Error: ' + this.message);
                 }
                 return formattedStack;
             }


### PR DESCRIPTION
The docs here: https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt

claim that the target of the `captureStackTrace` method's `.toString` method will be used to generate the error message line, but it doesn't seem to be so, at least on versions 5.3 and 5.9.1. Instead, just the vague string 'Error' is produced. This patch will replace either 'Error' or '[Object object]' at the start of the line with the custom message, instead of just '[Object object]'. It's worth noting that the test suite fails on recent versions of nodes for this reason, so I didn't need to add any tests to validate this patch -- they are already there.

Closes #14
